### PR TITLE
Dirty update

### DIFF
--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/UpdateEntities.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/UpdateEntities.java
@@ -33,7 +33,7 @@ public class UpdateEntities extends OctaneRequest {
 
     private Collection<EntityModel> entityModels = null;
 
-    protected UpdateEntities(OctaneHttpClient octaneHttpClient, String urlDomain) {
+    UpdateEntities(OctaneHttpClient octaneHttpClient, String urlDomain) {
         super (octaneHttpClient, urlDomain);
     }
 
@@ -44,7 +44,7 @@ public class UpdateEntities extends OctaneRequest {
     public Collection<EntityModel> execute() throws RuntimeException {
 
         Collection<EntityModel> newEntityModels = null;
-        JSONObject objBase = ModelParser.getInstance().getEntitiesJSONObject(entityModels);
+        JSONObject objBase = ModelParser.getInstance().getEntitiesJSONObject(entityModels, true);
         String jsonEntityModel = objBase.toString();
         try {
             OctaneHttpRequest octaneHttpRequest = new OctaneHttpRequest.PutOctaneHttpRequest(

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/UpdateEntity.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/entities/UpdateEntity.java
@@ -29,7 +29,7 @@ public class UpdateEntity extends OctaneRequest {
 
     private EntityModel entityModel;
 
-    protected UpdateEntity(OctaneHttpClient octaneHttpClient, String urlDomain, int iEntityId) {
+    UpdateEntity(OctaneHttpClient octaneHttpClient, String urlDomain, int iEntityId) {
         super(octaneHttpClient, urlDomain, iEntityId);
     }
 
@@ -40,7 +40,7 @@ public class UpdateEntity extends OctaneRequest {
     public EntityModel execute() {
 
         EntityModel newEntityModel = null;
-        JSONObject objBase = ModelParser.getInstance().getEntityJSONObject(entityModel);
+        JSONObject objBase = ModelParser.getInstance().getEntityJSONObject(entityModel, true);
         String jsonEntityModel = objBase.toString();
 
         try {

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/EntityModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/EntityModel.java
@@ -25,13 +25,19 @@ import java.util.stream.Collectors;
  * will be considered dirty and will be sent to the server when creating or updating.
  * When the entity has been returned from the server then the initial state will be considered clean.  Each change after
  * that (for example by using a method set*) will make the entity "dirty" and will be sent to the server when used for updates
+ * Note - the id field is <em>always</em> considered a dirty field since it needs to be added
  */
 public class EntityModel {
+
+    public static final String ID_FIELD_NAME = "id";
+
     /**
      * Represents the state of the entity.  In most cases it will be DIRTY.  However - when an entity is retrieved from the
      * server then the initial state will be CLEAN (all those fields will not be updated unless changed)
      */
-    public enum EntityState {CLEAN, DIRTY}
+    public enum EntityState {
+        CLEAN, DIRTY
+    }
 
     /**
      * Internal Map that keeps the state of fields to be updated
@@ -49,6 +55,7 @@ public class EntityModel {
 
         /**
          * Initialise the hashmap with this initial state
+         *
          * @param entityState The state to initialise the map
          */
         private DirtyHashMap(EntityState entityState) {
@@ -72,11 +79,16 @@ public class EntityModel {
 
         /**
          * Returns all values that are dirty
+         *
          * @return Dirty values
          */
         private Collection<FieldModel> dirtyValues() {
             return
-                    entrySet().stream().filter(entry -> dirtyFields.contains(entry.getKey())).map(Entry::getValue).collect(Collectors.toSet());
+                    entrySet()
+                            .stream()
+                            .filter(entry -> entry.getKey().equals(ID_FIELD_NAME) || dirtyFields.contains(entry.getKey()))
+                            .map(Entry::getValue)
+                            .collect(Collectors.toSet());
         }
     }
 
@@ -165,6 +177,7 @@ public class EntityModel {
 
     /**
      * Remove a value from completely, different from setting the value to null
+     *
      * @param key the fieldName
      */
     public void removeValue(String key) {

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/EntityModel.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/EntityModel.java
@@ -19,40 +19,114 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- *
  * This class hold the EntityModel objects and server as an entity data holder
  * entities.
- *
+ * The EntityModel class has two states - clean and dirty.  When creating a new entity from scratch then each addition
+ * will be considered dirty and will be sent to the server when creating or updating.
+ * When the entity has been returned from the server then the initial state will be considered clean.  Each change after
+ * that (for example by using a method set*) will make the entity "dirty" and will be sent to the server when used for updates
  */
 public class EntityModel {
-
-
-    private Map<String, FieldModel> data = null;
-
-    public EntityModel() {
-        data = new HashMap<>();
-    }
+    /**
+     * Represents the state of the entity.  In most cases it will be DIRTY.  However - when an entity is retrieved from the
+     * server then the initial state will be CLEAN (all those fields will not be updated unless changed)
+     */
+    public enum EntityState {CLEAN, DIRTY}
 
     /**
-     * Creates a new EntityModel object with given field models
-     * Use this when create entity model with mass of fields
-     *
-     * @param values - a collection of field models
+     * Internal Map that keeps the state of fields to be updated
      */
-    public EntityModel(Set<FieldModel> values) {
-        if (values != null) {
-            data = new HashMap<>(values.size());
-            values.forEach(field -> data.put(field.getName(), field));
-        } else {
-            data = new HashMap<>();
+    private final class DirtyHashMap extends HashMap<String, FieldModel> {
+
+        /**
+         * The fields that should be updated
+         */
+        private final Collection<String> dirtyFields = new HashSet<>();
+        /**
+         * The current state of the map
+         */
+        private EntityState entityState;
+
+        /**
+         * Initialise the hashmap with this initial state
+         * @param entityState The state to initialise the map
+         */
+        private DirtyHashMap(EntityState entityState) {
+            super();
+            this.entityState = entityState;
+        }
+
+        @Override
+        public final FieldModel put(String key, FieldModel value) {
+            if (entityState == EntityState.DIRTY) {
+                dirtyFields.add(key);
+            }
+            return super.put(key, value);
+        }
+
+        @Override
+        public void clear() {
+            super.clear();
+            dirtyFields.clear();
+        }
+
+        /**
+         * Returns all values that are dirty
+         * @return Dirty values
+         */
+        private Collection<FieldModel> dirtyValues() {
+            return
+                    entrySet().stream().filter(entry -> dirtyFields.contains(entry.getKey())).map(Entry::getValue).collect(Collectors.toSet());
         }
     }
 
     /**
+     * The internal map of data that this entity represents
+     */
+    private final DirtyHashMap data;
+
+    /**
+     * Creates a new EntityModel object
+     * All fields set after using this constructor will be considered "dirty"
+     */
+    public EntityModel() {
+        this(null, EntityState.DIRTY);
+    }
+
+    /**
+     * Creates a new EntityModel object with given field models
+     * Use this when create entity model with mass of fields.
+     * By using this constructor these fields will be considered to be the "dirty slate" of the entity.  In other words
+     * these fields as well as those set afterwards will be considered in any updates
+     *
+     * @param values - a collection of field models
+     */
+    public EntityModel(Set<FieldModel> values) {
+        this(values, EntityState.DIRTY);
+    }
+
+    /**
+     * Creates a new EntityModel object with given field models
+     * Use this when create entity model with mass of fields.
+     *
+     * @param values      - a collection of field models
+     * @param entityState The initial state of the entity when constructing.  Once these fields have been initialised
+     *                    the entity is considered to be dirty
+     */
+    public EntityModel(Set<FieldModel> values, EntityState entityState) {
+        data = new DirtyHashMap(entityState);
+        if (values != null) {
+            values.forEach(field -> data.put(field.getName(), field));
+        }
+        data.entityState = EntityState.DIRTY;
+    }
+
+    /**
      * Creates a new EntityModel object with solo string field
+     * The entity will be considered dirty and thus these fields will be updated
      *
      * @param value - a collection of field models
-     * @param key The key to the model
+     * @param key   The key to the model
      */
     public EntityModel(String key, String value) {
         this();
@@ -66,7 +140,17 @@ public class EntityModel {
      * @return a collection of field models
      */
     public Set<FieldModel> getValues() {
-        return data.values().stream().collect(Collectors.toSet());
+        return new HashSet<>(data.values());
+    }
+
+    /**
+     * Returns all dirty values.
+     * Used when sending the entity to be updated
+     *
+     * @return a collection of field models
+     */
+    Collection<FieldModel> getDirtyValues() {
+        return data.dirtyValues();
     }
 
     /**
@@ -93,6 +177,7 @@ public class EntityModel {
 
     /**
      * setter of single field, update if field exists
+     *
      * @param fieldModel the single field to update
      */
     public void setValue(FieldModel fieldModel) {

--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ModelParser.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/model/ModelParser.java
@@ -25,9 +25,6 @@ import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.IntStream;
 
-/**
- * Created by brucesp on 15-May-17.
- */
 public final class ModelParser {
     private static final String JSON_DATA_NAME = "data";
     private static final String JSON_ERRORS_NAME = "errors";
@@ -40,7 +37,8 @@ public final class ModelParser {
 
     private static ModelParser modelParser = new ModelParser();
 
-    private ModelParser(){}
+    private ModelParser() {
+    }
 
     public static ModelParser getInstance() {
         return modelParser;
@@ -53,8 +51,19 @@ public final class ModelParser {
      * @return new json object based on a given EntityModel object
      */
     public final JSONObject getEntityJSONObject(EntityModel entityModel) {
+        return getEntityJSONObject(entityModel, false);
+    }
 
-        Set<FieldModel> fieldModels = entityModel.getValues();
+    /**
+     * get a new json object based on a given EntityModel object
+     *
+     * @param entityModel the given entity model object
+     * @param onlyDirty   Return only dirty fields (used for updates)
+     * @return new json object based on a given EntityModel object
+     */
+    public final JSONObject getEntityJSONObject(EntityModel entityModel, boolean onlyDirty) {
+
+        Collection<FieldModel> fieldModels = onlyDirty ? entityModel.getDirtyValues() : entityModel.getValues();
         JSONObject objField = new JSONObject();
         fieldModels.forEach((i) -> objField.put(i.getName(), getFieldValue(i)));
 
@@ -68,13 +77,24 @@ public final class ModelParser {
      * @return new json object conatin entities data
      */
     public final JSONObject getEntitiesJSONObject(Collection<EntityModel> entitiesModels) {
+        return getEntitiesJSONObject(entitiesModels, false);
+    }
+
+    /**
+     * get a new json object based on a given EntityModel list
+     *
+     * @param entitiesModels - Collection of entities models
+     * @param onlyDirty      Converts only dirty fields (relevant for updating entity)
+     * @return new json object conatin entities data
+     */
+    public final JSONObject getEntitiesJSONObject(Collection<EntityModel> entitiesModels, boolean onlyDirty) {
 
         JSONObject objBase = new JSONObject();
         JSONArray objEntities = new JSONArray();
         objBase.put(JSON_DATA_NAME, objEntities);
         objBase.put(JSON_TOTAL_COUNT_NAME, entitiesModels.size());
         objBase.put(JSON_EXCEEDS_TOTAL_COUNT_NAME, false);
-        entitiesModels.forEach((i) -> objEntities.put(getEntityJSONObject(i)));
+        entitiesModels.forEach((i) -> objEntities.put(getEntityJSONObject(i, onlyDirty)));
 
         return objBase;
     }
@@ -85,22 +105,22 @@ public final class ModelParser {
      * @param fieldModel the source fieldModel
      * @return field value
      */
-    public Object getFieldValue(FieldModel fieldModel) {
+    private Object getFieldValue(FieldModel fieldModel) {
 
-        Object fieldValue = null;
+        Object fieldValue;
 
         if (fieldModel.getClass() == ReferenceFieldModel.class) {
             EntityModel fieldEntityModel = ((ReferenceFieldModel) fieldModel).getValue();
             fieldValue = JSONObject.NULL;
 
             if (fieldEntityModel != null) {
-                fieldValue = getEntityJSONObject(fieldEntityModel);
+                fieldValue = getEntityJSONObject(fieldEntityModel, false);
             }
 
         } else if (fieldModel.getClass() == MultiReferenceFieldModel.class) {
 
             Collection<EntityModel> entities = ((MultiReferenceFieldModel) fieldModel).getValue();
-            fieldValue = getEntitiesJSONObject(entities);
+            fieldValue = getEntitiesJSONObject(entities, false);
 
         } else {
 
@@ -166,7 +186,7 @@ public final class ModelParser {
             fieldModels.add(fldModel);
         }
 
-        entityModel = new EntityModel(fieldModels);
+        entityModel = new EntityModel(fieldModels, EntityModel.EntityState.CLEAN);
         return entityModel;
     }
 

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/model/TestModel.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/model/TestModel.java
@@ -128,7 +128,7 @@ public class TestModel {
     @Test
     public void testEntityModelWithLongField() {
         expectedResult = "{\"secondField\":200,\"firstField\":-200}";
-        set.add(new LongFieldModel("firstField", (long) -200));
+        set.add(new LongFieldModel("firstField", -200L));
         set.add(new LongFieldModel("secondField", 200L));
         model = new EntityModel(set);
         try {

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/model/TestModel.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/model/TestModel.java
@@ -14,8 +14,6 @@
  */
 package com.hpe.adm.nga.sdk.model;
 
-
-import com.hpe.adm.nga.sdk.model.*;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
@@ -24,10 +22,7 @@ import org.junit.Test;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -41,7 +36,7 @@ public class TestModel {
 
     @BeforeClass
     public static void initializeOnCreate() {
-        set = new HashSet<FieldModel>();
+        set = new HashSet<>();
     }
 
     @Before
@@ -133,8 +128,8 @@ public class TestModel {
     @Test
     public void testEntityModelWithLongField() {
         expectedResult = "{\"secondField\":200,\"firstField\":-200}";
-        set.add(new LongFieldModel("firstField", new Long(-200)));
-        set.add(new LongFieldModel("secondField", new Long(200)));
+        set.add(new LongFieldModel("firstField", (long) -200));
+        set.add(new LongFieldModel("secondField", 200L));
         model = new EntityModel(set);
         try {
             JSONObject outJsonEntity = ModelParser.getInstance().getEntityJSONObject(model);
@@ -161,8 +156,8 @@ public class TestModel {
     @Test
     public void testErrorModel() {
         expectedResult = "{\"secondField\":651651651,\"firstField\":0}";
-        set.add(new LongFieldModel("firstField", new Long(0)));
-        set.add(new LongFieldModel("secondField", new Long(651651651)));
+        set.add(new LongFieldModel("firstField", 0L));
+        set.add(new LongFieldModel("secondField", 651651651L));
         ErrorModel model = new ErrorModel(set);
         try {
             JSONObject outJsonEntity = ModelParser.getInstance().getEntityJSONObject(model);
@@ -198,7 +193,7 @@ public class TestModel {
         set.add(new MultiReferenceFieldModel("multiRefField", entityCol));
         set.add(new ReferenceFieldModel("RefField", refModel));
         set.add(new DateFieldModel("dateField", now));
-        set.add(new LongFieldModel("longField", new Long(200)));
+        set.add(new LongFieldModel("longField", 200L));
         set.add(new StringFieldModel("stringField", "first"));
         set.add(new BooleanFieldModel("boolField", true));
         model = new EntityModel(set);
@@ -236,5 +231,36 @@ public class TestModel {
         } catch (Exception ex) {
             fail("Failed with exception: " + ex);
         }
+    }
+
+    @Test
+    public void testDirtyEntity() {
+        // all fields should be dirty
+        model = new EntityModel();
+        model.setValue(new StringFieldModel("testKey", "testValue"));
+        final Set<FieldModel> values = model.getValues();
+        assertEquals(1, values.size());
+        assertEquals(1, model.getDirtyValues().size());
+    }
+
+    @Test
+    public void testNonDirtyEntity() {
+        // all fields should be dirty
+        model = new EntityModel(Collections.singleton(new StringFieldModel("testKey", "testValue")), EntityModel.EntityState.CLEAN);
+        final Set<FieldModel> values = model.getValues();
+        assertEquals(1, values.size());
+        assertEquals(0, model.getDirtyValues().size());
+    }
+
+    @Test
+    public void testNonDirtyEntityWithAddition() {
+        // all fields should be dirty
+        model = new EntityModel(Collections.singleton(new StringFieldModel("testKey", "testValue")), EntityModel.EntityState.CLEAN);
+        model.setValue(new StringFieldModel("testKey2", "testValue2"));
+        final Set<FieldModel> values = model.getValues();
+        assertEquals(2, values.size());
+        final Collection<FieldModel> dirtyValues = model.getDirtyValues();
+        assertEquals(1, dirtyValues.size());
+        assertEquals ("testKey2", (dirtyValues.iterator().next()).getName());
     }
 }

--- a/sdk-src/src/test/java/com/hpe/adm/nga/sdk/model/TestModel.java
+++ b/sdk-src/src/test/java/com/hpe/adm/nga/sdk/model/TestModel.java
@@ -263,4 +263,14 @@ public class TestModel {
         assertEquals(1, dirtyValues.size());
         assertEquals ("testKey2", (dirtyValues.iterator().next()).getName());
     }
+
+    @Test
+    public void testCleanEntityWithId() {
+        // all fields should be dirty
+        model = new EntityModel(Collections.singleton(new StringFieldModel("id", "idValue")), EntityModel.EntityState.CLEAN);
+        final Set<FieldModel> values = model.getValues();
+        assertEquals(1, values.size());
+        final Collection<FieldModel> dirtyValues = model.getDirtyValues();
+        assertEquals(1, dirtyValues.size());
+    }
 }


### PR DESCRIPTION
When updating from an entity that was created from the server all fields were sent back.  This caused two problems:

1. Data was sent to the server that was unnecessary
2. Due to the above uneditable data was sent which caused a failure on the server

I have added functionality to check for dirtiness so that only dirty fields are sent back