### PR TITLE
defect #438045: Fixed issue where calling the authenticate method rep…

### DIFF
--- a/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/google/GoogleHttpClient.java
+++ b/sdk-src/src/main/java/com/hpe/adm/nga/sdk/network/google/GoogleHttpClient.java
@@ -104,6 +104,7 @@ public class GoogleHttpClient implements OctaneHttpClient {
      * @return - Returns true if the authentication succeeded, false otherwise.
      */
     public boolean authenticate(Authentication authentication) {
+        lwssoValue = null;
         lastUsedAuthentication = authentication;
         try {
             final ByteArrayContent content = ByteArrayContent.fromString("application/json", authentication.getAuthenticationString());


### PR DESCRIPTION
…eatedly might return a cached response / LWSSO header (304), even though this header has expired.

This would cause the session expired handling code to now work.